### PR TITLE
Refactor/prefic routes with '/api'

### DIFF
--- a/app/views/auth.py
+++ b/app/views/auth.py
@@ -6,7 +6,7 @@ from models.user import User
 from urllib.parse import urlsplit
 
 
-auth_bl = Blueprint('auth', __file__)
+auth_bl = Blueprint('auth', __file__, url_prefix='/api')
 
 @auth_bl.route('/login', methods=['GET', 'POST'], strict_slashes=False)
 def login():

--- a/app/views/emails.py
+++ b/app/views/emails.py
@@ -5,7 +5,7 @@ from flask_login import login_required, current_user
 from itsdangerous import BadSignature, SignatureExpired
 from models.user import User
 
-email_bl = Blueprint('email_bl', __name__)
+email_bl = Blueprint('email_bl', __name__, url_prefix='/api')
 
 
 @email_bl.get('/confirm_email/<token>')

--- a/app/views/household_shopping_list.py
+++ b/app/views/household_shopping_list.py
@@ -6,7 +6,8 @@ from models.household import Household, ShoppingListItem
 from models.user import User
 from app.utils.middleware import household_member_required
 
-household_shopping_list_bl = Blueprint('household shopping list', __name__)
+household_shopping_list_bl = Blueprint(
+    'household shopping list', __name__, url_prefix='/api')
 
 
 @household_shopping_list_bl.post('/households/shopping_list/items', strict_slashes=False)

--- a/app/views/households.py
+++ b/app/views/households.py
@@ -9,7 +9,7 @@ from app.utils.middleware import household_member_required, \
     household_admin_required
 from werkzeug.security import generate_password_hash
 
-household_bl = Blueprint('households', __name__)
+household_bl = Blueprint('households', __name__, url_prefix='/api')
 
 
 @household_bl.post('/households', strict_slashes=False)

--- a/app/views/users.py
+++ b/app/views/users.py
@@ -7,7 +7,7 @@ from app.utils.valid_data import is_valid_password
 from app.utils.email_services import send_confirmation_email
 
 
-user_bl = Blueprint('users', __name__)
+user_bl = Blueprint('users', __name__, url_prefix='/api')
 
 @user_bl.post('/users', strict_slashes=False)
 def create_user():

--- a/app/views/users.py
+++ b/app/views/users.py
@@ -79,7 +79,7 @@ def get_specific_user():
     }), 200
 
 
-@user_bl.patch('/users/me', strict_slashes=False)
+@user_bl.patch('/users/me/username', strict_slashes=False)
 @login_required
 def update_user():
     """UPDATES the logged-in user's profile details.


### PR DESCRIPTION
Refactors all the view function's routes by prefixing them with the phrase '/api'.
This is done for better readability when using the API as one who uses it can more clearly see that they are likely accessing a back-end directly.